### PR TITLE
refactor boards labels link relations: board now has links relationship

### DIFF
--- a/src/features/boards/BoardInfo.tsx
+++ b/src/features/boards/BoardInfo.tsx
@@ -6,14 +6,12 @@ import {
   searchLabels,
   selectBoardById,
   selectSearchLabels,
-  setBoardLabelsFilters,
 } from '~/features/boards/slice'
 import { Checkbox, FormControlLabel, FormGroup, IconButton, InputAdornment, InputBase } from '@material-ui/core'
 import SearchIcon from '@material-ui/icons/Search'
 import ClearIcon from '@material-ui/icons/Clear'
 import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft'
 import Card from '@material-ui/core/Card'
-import { selectLabelsFilteredBySearchWord } from '~/features/labels/slice'
 import { LabelTag } from '~/features/labels'
 import { fetchUserInfo, selectUserById } from '~/features/users/slice'
 
@@ -136,97 +134,98 @@ const SearchLabels = (props: SearchLabelsProps) => {
   )
 }
 
-const LabelsIcon = styled(LocalOfferIcon)`
-  margin-right: 8px;
-`
+// const LabelsIcon = styled(LocalOfferIcon)`
+//   margin-right: 8px;
+// `
+//
+// const BoardLabelsContent = styled.div`
+//   margin: 4px 36px 0 36px;
+// `
 
-const BoardLabelsContent = styled.div`
-  margin: 4px 36px 0 36px;
-`
+// const LabelsCard = styled(Card)`
+//   height: 400px;
+//   border-radius: 14px;
+//   background: #f4f3f35c;
+//
+//   display: flex;
+//   flex-direction: column;
+//   align-content: flex-start;
+// `
 
-const LabelsCard = styled(Card)`
-  height: 400px;
-  border-radius: 14px;
-  background: #f4f3f35c;
-  
-  display: flex;
-  flex-direction: column;
-  align-content: flex-start;
-`
+// const LabelsGroup = styled(FormGroup)`
+//     margin: 8px 8px 0 16px;
+// `
+//
+// const LabelCheckbox = styled(Checkbox)`
+//   // TODO: fix without using important
+//   padding: 0 !important;
+// `
+//
+// interface BoardLabelsProps {
+//   boardId: number
+//   labels: number[]
+//   boardLabels: number[]
+// }
 
-const LabelsGroup = styled(FormGroup)`
-    margin: 8px 8px 0 16px;
-`
-
-const LabelCheckbox = styled(Checkbox)`
-  // TODO: fix without using important
-  padding: 0 !important;
-`
-
-interface BoardLabelsProps {
-  boardId: number
-  labels: number[]
-  boardLabels: number[]
-}
-
-const BoardLabels = (props: BoardLabelsProps) => {
-  const { boardId, labels, boardLabels } = props
-
-  const dispatch = useAppDispatch()
-
-  const onLabelCheckboxClick = useCallback((selectedLabelId: number, event: React.ChangeEvent<HTMLInputElement>) => {
-    const { checked } = event.target
-    let updatedLabels
-    if (checked) {
-      updatedLabels = [...boardLabels, selectedLabelId]
-    }
-    else {
-      updatedLabels = boardLabels.filter((labelId) => labelId !== selectedLabelId)
-    }
-
-    dispatch(setBoardLabelsFilters({
-      boardId,
-      labelsFilters: updatedLabels,
-    }))
-  }, [boardLabels])
-
-  return (
-    <Section
-      title="Board Labels"
-      icon={
-        <LabelsIcon />
-      }
-    >
-      <BoardLabelsContent>
-        <SearchLabels />
-        <LabelsCard square={false} elevation={2}>
-          <LabelsGroup>
-            {
-              labels.map((labelId) => (
-                <FormControlLabel
-                  key={`board-label-form-control-${labelId}`}
-                  control={
-                    <LabelCheckbox
-                      size="small"
-                      checked={boardLabels.includes(labelId)}
-                      onChange={(event) => onLabelCheckboxClick(labelId, event)}
-                    />
-                  }
-                  label={
-                    <LabelTag
-                      key={`board-label-${labelId}`}
-                      labelId={labelId}
-                    />
-                  }
-                />
-              ))
-            }
-          </LabelsGroup>
-        </LabelsCard>
-      </BoardLabelsContent>
-    </Section>
-  )
-}
+// TODO: move to another place and use to filter links by labels
+// const BoardLabels = (props: BoardLabelsProps) => {
+//   const { boardId, labels, boardLabels } = props
+//
+//   const dispatch = useAppDispatch()
+//
+//   const onLabelCheckboxClick = useCallback((selectedLabelId: number, event: React.ChangeEvent<HTMLInputElement>) => {
+//     const { checked } = event.target
+//     let updatedLabels
+//     if (checked) {
+//       updatedLabels = [...boardLabels, selectedLabelId]
+//     }
+//     else {
+//       updatedLabels = boardLabels.filter((labelId) => labelId !== selectedLabelId)
+//     }
+//
+//     dispatch(setBoardLabelsFilters({
+//       boardId,
+//       labelsFilters: updatedLabels,
+//     }))
+//   }, [boardLabels])
+//
+//   return (
+//     <Section
+//       title="Board Labels"
+//       icon={
+//         <LabelsIcon />
+//       }
+//     >
+//       <BoardLabelsContent>
+//         <SearchLabels />
+//         <LabelsCard square={false} elevation={2}>
+//           <LabelsGroup>
+//             {
+//               labels.map((labelId) => (
+//                 <FormControlLabel
+//                   key={`board-label-form-control-${labelId}`}
+//                   control={
+//                     <LabelCheckbox
+//                       size="small"
+//                       checked={boardLabels.includes(labelId)}
+//                       onChange={(event) => onLabelCheckboxClick(labelId, event)}
+//                     />
+//                   }
+//                   label={
+//                     <LabelTag
+//                       key={`board-label-${labelId}`}
+//                       labelId={labelId}
+//                     />
+//                   }
+//                 />
+//               ))
+//             }
+//           </LabelsGroup>
+//         </LabelsCard>
+//       </BoardLabelsContent>
+//     </Section>
+//   )
+// }
 
 const AboutIcon = styled(FormatAlignLeftIcon)`
   margin-right: 8px;
@@ -312,9 +311,9 @@ const BoardInfo = (props: BoardInfoProps) => {
   const dispatch = useAppDispatch()
   const board = useAppSelector(selectBoardById(boardId))
   if (!board) return null
+
   const userInfo = useAppSelector(selectUserById(board.createdByUserId))
   const searchLabelsWord = useAppSelector(selectSearchLabels)
-  const labels = useAppSelector(selectLabelsFilteredBySearchWord(searchLabelsWord))
 
   useEffect(() => {
     if (userInfo === undefined) {
@@ -335,11 +334,7 @@ const BoardInfo = (props: BoardInfoProps) => {
       <Description
         description={board.description}
       />
-      <BoardLabels
-        boardId={board.id}
-        labels={labels.map((label) => label.id)}
-        boardLabels={board.labelsFilters}
-      />
+
       <About
         createdAt={board.createdAt}
         updatedAt={board.updatedAt}

--- a/src/features/boards/service.ts
+++ b/src/features/boards/service.ts
@@ -13,22 +13,8 @@ class BoardService {
       createdAt: board.created_at,
       updatedAt: board.updated_at,
       createdByUserId: board.created_by_user_id,
-      labelsFilters: board.labels_filters,
+      links: board.links,
     }))
-  }
-
-  async setBoardLabelsFilters(boardId: number, labelsFilters: number[]): Promise<types.Board> {
-    const board = (await ApiClient.post<types.BoardResponse>(`/boards/${boardId}/set_labels_filters`, labelsFilters)).data
-
-    return {
-      id: board.id,
-      name: board.name,
-      description: board.description,
-      createdAt: board.created_at,
-      updatedAt: board.updated_at,
-      createdByUserId: board.created_by_user_id,
-      labelsFilters: board.labels_filters,
-    }
   }
 }
 

--- a/src/features/boards/slice.ts
+++ b/src/features/boards/slice.ts
@@ -16,18 +16,6 @@ export const fetchBoards = createAsyncThunk<types.Board[]>(
   },
 )
 
-interface setBoardLabelsFiltersPayload {
-  boardId: number
-  labelsFilters: number[]
-}
-
-export const setBoardLabelsFilters = createAsyncThunk<types.Board, setBoardLabelsFiltersPayload>(
-  'boards/setBoardLabelsFilters',
-  async ({ boardId, labelsFilters }) => {
-    return await BoardService.setBoardLabelsFilters(boardId, labelsFilters)
-  },
-)
-
 interface BoardsState {
   boards: types.Board[],
   searchLabelsWord: string,
@@ -55,11 +43,6 @@ export const boardsSlice = createSlice({
         ...board,
         id: Number(String(board.id) + String(idx)),
       }))).flat())
-    })
-
-    builder.addCase(setBoardLabelsFilters.fulfilled, (state, action) => {
-      const updatedBoard = action.payload
-      state.boards = state.boards.map((board) => board.id === updatedBoard.id ? updatedBoard : board)
     })
   },
 })

--- a/src/features/boards/types.ts
+++ b/src/features/boards/types.ts
@@ -7,7 +7,7 @@ export interface BoardResponse {
   created_at: Date,
   updated_at: Date,
   created_by_user_id: number,
-  labels_filters: number[],
+  links: number[],
 }
 /* eslint-enable camelcase */
 
@@ -18,5 +18,5 @@ export interface Board {
   createdAt: Date,
   updatedAt: Date,
   createdByUserId: number,
-  labelsFilters: number[],
+  links: number[],
 }

--- a/src/features/links/slice.ts
+++ b/src/features/links/slice.ts
@@ -38,7 +38,7 @@ export const linksSlice = createSlice({
         ...link,
         id: Number(String(link.id) + String(idx)),
       })))
-      state.links = duplicatedLinks.flat()
+      state.links = [...action.payload, ...duplicatedLinks.flat()]
     })
   },
 })
@@ -55,6 +55,12 @@ export const selectLinkById = (linkId: number) => (state: RootState) => {
   const links = selectAllLinks(state)
 
   return links.find((link) => link.id === linkId)
+}
+
+export const selectLinksByIds = (linksIds: number[]) => (state: RootState) => {
+  const links = selectAllLinks(state)
+
+  return links.filter((link) => linksIds.includes(link.id))
 }
 
 export const selectLinksByLabels = (labelsIds: number[]) => (state: RootState) => {
@@ -74,10 +80,17 @@ export const selectLinksFilteredBySearchWord = (searchWord: string) => (state: R
   return filterLinksBySearchWord(links, searchWord)
 }
 
+export const selectLinksByIdsFilteredBySearchWord = (linksIds: number[], searchWord: string) =>
+  (state: RootState) => {
+    const links = selectLinksByIds(linksIds)(state)
+
+    return filterLinksBySearchWord(links, searchWord)
+  }
+
 export const selectLinksByLabelsFilteredBySearchWord = (labelsIds: number[] | null, searchWord: string) =>
   (state: RootState) => {
     let links
-    if (labelsIds !== null ) {
+    if (labelsIds !== null) {
       links = selectLinksByLabels(labelsIds)(state)
     }
     else {


### PR DESCRIPTION
Using board.links instead of links filtered by label ids since server is no longer using labels to set board's links